### PR TITLE
adds composer require command

### DIFF
--- a/bin/micro.php
+++ b/bin/micro.php
@@ -31,4 +31,5 @@ $application->add(new Command\CreatePostgresCommand());
 $application->add(new Command\CreatePhpServiceCommand());
 $application->add(new Command\ComposerInstallCommand());
 $application->add(new Command\ComposerUpdateCommand());
+$application->add(new Command\ComposerRequireCommand());
 $application->run();

--- a/src/Command/AbstractComposerCommand.php
+++ b/src/Command/AbstractComposerCommand.php
@@ -137,28 +137,28 @@ abstract class AbstractComposerCommand extends AbstractCommand
         return $phpServices;
     }
 
-    private function getRequestedServices(InputInterface $input, OutputStyle $io, array $requestedServices): array
+    private function getRequestedServices(InputInterface $input, OutputStyle $io, array $declaredPhpServices): array
     {
         if ($input->getOption('all')) {
-            return $requestedServices;
+            return $declaredPhpServices;
         }
 
         $requestedService = $input->getArgument('service');
 
-        if ($requestedService && ! array_key_exists($requestedService, $requestedServices)) {
+        if ($requestedService && ! array_key_exists($requestedService, $declaredPhpServices)) {
             $io->warning("Service with name '$requestedService' is not configured in docker-compose.yml yet.");
             $requestedService = null;
         }
 
         if (! $requestedService) {
-            $requestedService = $io->choice('Select a service', array_keys($requestedServices));
+            $requestedService = $io->choice('Select a service', array_keys($declaredPhpServices));
         }
 
-        if (! array_key_exists($requestedService, $requestedServices)) {
+        if (! array_key_exists($requestedService, $declaredPhpServices)) {
             throw new \RuntimeException('Invalid service name provided.');
         }
 
-        return [$requestedService => $requestedServices[$requestedService]];
+        return [$requestedService => $declaredPhpServices[$requestedService]];
     }
 
     private function getDockerComposeExecutable(InputInterface $input): string

--- a/src/Command/ComposerRequireCommand.php
+++ b/src/Command/ComposerRequireCommand.php
@@ -139,28 +139,28 @@ class ComposerRequireCommand extends AbstractCommand
         return $phpServices;
     }
 
-    private function getRequestedServices(InputInterface $input, OutputStyle $io, array $requestedServices): array
+    private function getRequestedServices(InputInterface $input, OutputStyle $io, array $declaredPhpServices): array
     {
         if ($input->getOption('all')) {
-            return $requestedServices;
+            return $declaredPhpServices;
         }
 
         $requestedService = $input->getArgument('service');
 
-        if ($requestedService && ! array_key_exists($requestedService, $requestedServices)) {
+        if ($requestedService && ! array_key_exists($requestedService, $declaredPhpServices)) {
             $io->warning("Service with name '$requestedService' is not configured in docker-compose.yml yet.");
             $requestedService = null;
         }
 
         if (! $requestedService) {
-            $requestedService = $io->choice('Select a service', array_keys($requestedServices));
+            $requestedService = $io->choice('Select a service', array_keys($declaredPhpServices));
         }
 
-        if (! array_key_exists($requestedService, $requestedServices)) {
+        if (! array_key_exists($requestedService, $declaredPhpServices)) {
             throw new \RuntimeException('Invalid service name provided.');
         }
 
-        return [$requestedService => $requestedServices[$requestedService]];
+        return [$requestedService => $declaredPhpServices[$requestedService]];
     }
 
     private function getDockerComposeExecutable(InputInterface $input): string

--- a/src/Command/ComposerRequireCommand.php
+++ b/src/Command/ComposerRequireCommand.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * This file is part of the prooph/micro-cli.
+ * (c) 2017-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\MicroCli\Command;
+
+use Symfony\Component\Console\Helper\ProcessHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\OutputStyle;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\ProcessBuilder;
+
+class ComposerRequireCommand extends AbstractCommand
+{
+    private const DEFAULT_TIMEOUT = 0;
+    private const DEFAULT_IDLE_TIMEOUT = 30;
+
+    protected function configure()
+    {
+        $this
+            ->setName('micro:composer:require')
+            ->setDescription('Adds package as composer dependencies for services')
+            ->addArgument('package', InputArgument::REQUIRED)
+            ->addArgument('service', InputArgument::OPTIONAL)
+            ->addOption('all', '-a', InputOption::VALUE_NONE)
+            ->addOption(
+                'timeout',
+                '-t',
+                InputOption::VALUE_REQUIRED,
+                'Sets the process timeout (max. runtime) per service in seconds',
+                self::DEFAULT_TIMEOUT
+            )
+            ->addOption(
+                'idle-timeout',
+                '-i',
+                InputOption::VALUE_REQUIRED,
+                'Sets the process idle timeout (max. time since last output) per service in seconds',
+                self::DEFAULT_IDLE_TIMEOUT
+            )
+            ->addOption(
+                'docker-executable',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Sets the path to docker executable'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $declaredPhpServices = $this->getDeclaredPhpServices();
+
+        if (! $declaredPhpServices) {
+            $io->warning('No php services declared in docker-compose.yml or no composer.json files found. Aborting');
+
+            return 1;
+        }
+
+        $requestedServices = $this->getRequestedServices($input, $io, $declaredPhpServices);
+
+        $timeout = (int) $input->getOption('timeout');
+        $idleTimeout = (int) $input->getOption('idle-timeout');
+        $dockerExecutable = $this->getDockerComposeExecutable($input);
+
+        $processBuilder = new ProcessBuilder();
+        $processBuilder->setPrefix($dockerExecutable);
+        $processBuilder->setTimeout($timeout);
+
+        /** @var ProcessHelper $processHelper */
+        $processHelper = $this->getHelper('process');
+
+        $package = $input->getArgument('package');
+
+        foreach ($requestedServices as $service => $values) {
+            $io->newLine(2);
+            $io->section("Run `docker-compose require` for service $service");
+
+            $processBuilder->setArguments([
+                'run',
+                '--rm',
+                '--env',
+                'COMPOSER_ALLOW_SUPERUSER=1',
+                '--volume',
+                $this->getServiceDirPath($service) . ':/app:rw',
+                'prooph/composer:'. $values['php_version'],
+                'require',
+                $package,
+                '--no-interaction',
+                '--no-suggest',
+            ]);
+
+            $process = $processBuilder->getProcess();
+            $process->setIdleTimeout($idleTimeout);
+
+            $processHelper->mustRun($output, $process, null, function ($type, $buffer) use ($io) {
+                $io->write("$buffer");
+            });
+        }
+
+        return 0;
+    }
+
+    private function getDeclaredPhpServices(): array
+    {
+        $phpServices = [];
+        $dockerComposeConfig = $this->getDockerComposeConfig();
+
+        foreach ($dockerComposeConfig['services'] as $service => $serviceConfig) {
+            if (! isset($serviceConfig['image'])) {
+                continue;
+            }
+
+            if (! preg_match('/^prooph\/php:([0-9\.]+)/', $serviceConfig['image'], $phpVersionMatches)) {
+                continue;
+            }
+
+            if (! file_exists($this->getServiceDirPath($service) . '/composer.json')) {
+                continue;
+            }
+
+            $phpServices[$service] = [
+                'php_version' => $phpVersionMatches[1],
+            ];
+        }
+
+        return $phpServices;
+    }
+
+    private function getRequestedServices(InputInterface $input, OutputStyle $io, array $requestedServices): array
+    {
+        if ($input->getOption('all')) {
+            return $requestedServices;
+        }
+
+        $requestedService = $input->getArgument('service');
+
+        if ($requestedService && ! array_key_exists($requestedService, $requestedServices)) {
+            $io->warning("Service with name '$requestedService' is not configured in docker-compose.yml yet.");
+            $requestedService = null;
+        }
+
+        if (! $requestedService) {
+            $requestedService = $io->choice('Select a service', array_keys($requestedServices));
+        }
+
+        if (! array_key_exists($requestedService, $requestedServices)) {
+            throw new \RuntimeException('Invalid service name provided.');
+        }
+
+        return [$requestedService => $requestedServices[$requestedService]];
+    }
+
+    private function getDockerComposeExecutable(InputInterface $input): string
+    {
+        static $executableFinder = null;
+
+        $dockerExecutable = $input->getOption('docker-executable');
+
+        if (null !== $dockerExecutable) {
+            return $dockerExecutable;
+        }
+
+        if (null === $executableFinder) {
+            $executableFinder = new ExecutableFinder();
+        }
+
+        $dockerComposePath = $executableFinder->find('docker', null);
+
+        if (null === $dockerComposePath) {
+            throw new \RuntimeException(
+                'Could not detect docker executable. Please provide it with --docker-executable option.'
+            );
+        }
+
+        return $dockerComposePath;
+    }
+}

--- a/tests/Command/ComposerInstallCommandTest.php
+++ b/tests/Command/ComposerInstallCommandTest.php
@@ -17,7 +17,7 @@ use Prooph\MicroCli\Command\ComposerInstallCommand;
 /**
  * @coversDefaultClass Prooph\MicroCli\Command\ComposerInstallCommand
  */
-final class ComposerInstallCommandTest extends ComposerCommandTestCase
+class ComposerInstallCommandTest extends ComposerCommandTestCase
 {
     protected function getComposerCommandClass(): string
     {

--- a/tests/Command/ComposerRequireCommandTest.php
+++ b/tests/Command/ComposerRequireCommandTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @coversDefaultClass \Prooph\MicroCli\Command\ComposerRequireCommand
  */
-final class ComposerRequireCommandTest extends TestCase
+class ComposerRequireCommandTest extends TestCase
 {
     /**
      * @var ComposerRequireCommand

--- a/tests/Command/ComposerUpdateCommandTest.php
+++ b/tests/Command/ComposerUpdateCommandTest.php
@@ -17,7 +17,7 @@ use Prooph\MicroCli\Command\ComposerUpdateCommand;
 /**
  * @coversDefaultClass Prooph\MicroCli\Command\ComposerUpdateCommand
  */
-final class ComposerUpdateCommandTest extends ComposerCommandTestCase
+class ComposerUpdateCommandTest extends ComposerCommandTestCase
 {
     protected function getComposerCommandClass(): string
     {


### PR DESCRIPTION
This PR closes #2 

Since the require command needs a package as argument, I have had to copy the abstract composer command content. Other implementations would patch around the current abstract implementation and was to messy I guess. Also with unit tests.

Another way would be to group `update` and `require` together, since booth could have a package as argument, but `install` has not.

But for now I am fine with that.